### PR TITLE
use xenial since Trusty is EOL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: c
 script:
   - docker run -v `pwd`:/opt/tree -w /opt/tree -t toaruos/build-tools:test util/build-travis.sh
 sudo: required
-dist: trusty
+dist: xenial
 serivces:
   - docker
 before_install:


### PR DESCRIPTION
Since Trusty is EOL, use xenial