### PR TITLE
Fixing typo

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,9 +1,9 @@
 
 University of Illinois/NCSA Open Source License
 
-Copyright (c) 2011-2021 K Lange, et al. (hereafter [fullname]). All rights reserved.
+Copyright (c) 2011-2021 K Lange, et al. (hereafter K Lange). All rights reserved.
 
-Developed by: ToaruOS (hereafter [project])
+Developed by: ToaruOS (hereafter PonyOS)
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation files
@@ -20,7 +20,7 @@ subject to the following conditions:
   notice, this list of conditions and the following disclaimers in the
   documentation and/or other materials provided with the distribution.
 
-* Neither the names of [fullname], [project] nor the names of its
+* Neither the names of K Lange, PonyOS nor the names of its
   contributors may be used to endorse or promote products derived from
   this Software without specific prior written permission.
 


### PR DESCRIPTION
The license needed the name and project added into the license in some spots